### PR TITLE
should fold ascii only words when no UTF-8 encoding

### DIFF
--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -148,7 +148,7 @@ module Mail
         first_word = true
         while !words.empty?
           break unless word = words.first.dup
-          word.encode!(charset) if charset && word.respond_to?(:encode!)
+          word.encode!(charset) if should_encode && charset && word.respond_to?(:encode!)
           word = encode(word) if should_encode
           word = encode_crlf(word)
           # Skip to next line if we're going to go past the limit

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -185,6 +185,12 @@ describe Mail::UnstructuredField do
       expect(@field.encoded).to eq result
     end
 
+    it "should fold ascii only words when no UTF-8 encoding" do
+      @field = Mail::UnstructuredField.new("X-Subject", "This is a header only ascii", "iso-2022-jp")
+      result = "X-Subject: This is a header only ascii\r\n"
+      expect(@field.encoded).to eq result
+    end
+
   end
 
   describe "encoding non QP safe chars" do


### PR DESCRIPTION
The patche for the custome header when japanese encodeing charset.
It is talk in https://github.com/mikel/mail/issues/410.